### PR TITLE
Bugfix in `get_authorisation_code` and usability improvement.

### DIFF
--- a/esy/devel.py
+++ b/esy/devel.py
@@ -1,6 +1,7 @@
 from http.server import HTTPServer, BaseHTTPRequestHandler
 import os
 import threading
+import webbrowser
 import urllib.parse
 from requests_html import HTMLSession
 from requests import Request
@@ -103,6 +104,7 @@ def get_authorization_code(cli_login=False, server_address=SERVER_ADDRESS,
         }).prepare()
         print('Please complete the EVE SSO authentication: {}'.format(
             request.url))
+        webbrowser.open(request.url)
 
     dev_server.join()
     if SESSION['state'] != state:

--- a/esy/devel.py
+++ b/esy/devel.py
@@ -1,6 +1,7 @@
 from http.server import HTTPServer, BaseHTTPRequestHandler
 import os
 import threading
+import urllib.parse
 from requests_html import HTMLSession
 from requests import Request
 import random
@@ -32,11 +33,9 @@ class AuthenticationHandler(BaseHTTPRequestHandler):
                            '</html>', encoding='utf-8')
 
     def do_GET(self):
-        # First split for the last /, then strip '?', then split by '&'
-        params = self.path.split('/')[-1][1:].split('&')
-        for param in params:
-            key, value = param.split('=')
-            SESSION[key] = value
+        parsed = urllib.parse.urlparse(self.path)
+        for k, v in urllib.parse.parse_qs(parsed.query).items():
+            SESSION[k] = ','.join(v)
         self.send_response(200)
         self.end_headers()
         self.request.send(self.DEVSERVER_HTML)


### PR DESCRIPTION
After a couple hours struggling with the oauth for SSI and trying to have it open within a browser, implementing a small webserver myself, etc. I decided to google **again**, this problem had to be solved. That's when I stumbled on this project, it looks very promising. If you don't mind I'll be contributing here instead of implementing my own library for ESI.

**Anyway, on-topic:** This PR fixes a small bug. When `callback_url` did not end with a slash the authorization code wasn't correctly extracted. This is now fixed by using `urlparse` to do the parsing.

I also added `webbrowser.open()` so that you don't have to manually click the url. (I'm lazy.)