### PR TITLE
Fix typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ char_info = esy.devel.verify_access_token(access_token)
 from esy.client import ESIClient
 client = ESIClient.get_client(user_agent='your-user-agent')
 assets = client.Assets.get_characters_character_id_assets(
-    character_id=char_info.get('CharacterId'), _token=access_token)
+    character_id=char_info.get('CharacterID'), _token=access_token)
 
 for page in assets:
     print(page)


### PR DESCRIPTION
The correct dict key is `CharacterID`, not `CharacterId`.

Also, Github search for `CharacterId` on your repository returned a usage inside actual code:
https://github.com/kriberg/esy/blob/ae66b160052dfed7a8979fbc406667221f146ee7/esy/devel.py#L163
Out of context I'm not sure if that is correct or also a typo. (Seems you are parsing some HTML form there, so maybe it's something different?)